### PR TITLE
Refactor the preview/deploy gh actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,50 @@
+name: build-book
+
+# Trigger the workflow on push to main branch and PRs
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+# This job installs dependencies, builds the book, and deploys the html
+jobs:
+  build-and-deploy-book:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.8]
+    steps:
+    - uses: actions/checkout@v2
+
+    # Install dependencies
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt
+    # Build the book
+    - name: Build the book
+      run: |
+        jupyter-book build book
+    
+    # Zip the book for artifact upload
+    - name: Zip-book
+      run: |
+        set -x
+        set -e
+        if [ -f book.zip ]; then
+            rm -rf book.zip
+        fi
+        zip -r book.zip book/_build/html
+    
+    # Upload zipped book for preview action
+    - uses: actions/upload-artifact@v3
+      with:
+        name: book-zip
+        path: ./book.zip

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,58 +1,44 @@
 name: deploy-book
 
-# Trigger the workflow on push to main branch and PRs
+# Trigger This workflow only once the book build is completed
 on:
-  push:
-    branches:
-    - main
-  pull_request:
-    branches:
-    - main
+  workflow_run:
+    workflows:
+      - build-book
+    types:
+      - completed
 
 # This job installs dependencies, builds the book, and deploys the html
 jobs:
-  build-and-deploy-book:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.8]
+  deploy:
+    # only run this when pushed to main
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
-    - uses: actions/checkout@v2
-
-    # Install dependencies
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        pip install -r requirements.txt
-
-    # Build the book
-    - name: Build the book
-      run: |
-        jupyter-book build book
     
-    # Zip the book for artifact upload
-    - name: Zip-book
-      run: |
-        set -x
-        set -e
-        if [ -f book.zip ]; then
-            rm -rf book.zip
-        fi
-        zip -r book.zip book/_build/html
-    
-    # Upload zipped book for preview action
-    - uses: actions/upload-artifact@v3
+    # download the artifact
+    - name: Download Artifact site
+      uses: dawidd6/action-download-artifact@v2.14.1
       with:
-        name: book-zip
-        path: ./book.zip
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: build.yaml
+          run_id: ${{ github.event.workflow_run.id }}s
+          name: book-zip
+    
+    # Download the artifact (zipped html output)
+    - name: Unzip site
+      run: |
+          rm -rf book/_build/html
+          unzip book.zip
+          rm -f book.zip
 
-    # Deploy the book's html to earth-env-data-science.github.io
+    # Deploy the book's html to github pages
     - name: GitHub Pages action
-      if: github.ref == 'refs/heads/main'
+      # Double Check that this is the correct repo
+      if: github.repository == 'leap-stc/leap-stc.github.io'
       uses: peaceiris/actions-gh-pages@v3
       with:
         publish_branch: gh-pages

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -4,7 +4,6 @@ on:
     workflows:
       - deploy-book
     types:
-      - requested
       - completed
 jobs:
   deploy:
@@ -84,7 +83,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v2.14.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: deploy.yaml
+          workflow: build.yaml
           run_id: ${{ github.event.workflow_run.id }}
           name: book-zip
 


### PR DESCRIPTION
I am trying to prevent these annoying [action failures](https://github.com/leap-stc/leap-stc.github.io/actions/runs/3907052895). They seem to happen when something prevents a zip file from being uploaded (presumably a cancelled deploy action due to rapid succession of pushes?).
I have split the build stage out of the deploy action and both preview and deploy now rely on the zipped/uploaded artifact from `build.yaml`. This might make the preview commenting a bit slower, but I prefer that to the fact that I end up with tons of notifications in my inbox.