### PR TITLE
Fix deployment actions

### DIFF
--- a/.github/workflows/publish-book.yaml
+++ b/.github/workflows/publish-book.yaml
@@ -17,4 +17,8 @@ jobs:
 
   deploy:
     needs: build
-    uses: ProjectPythia/cookbook-actions/.github/workflows/deploy-book.yaml@main
+    # uses: ProjectPythia/cookbook-actions/.github/workflows/deploy-book.yaml@main
+    # for testing
+    uses: jbusecke/cookbook-actions/.github/workflows/deploy-book.yaml@patch-3
+    with:
+      publish_dir: "book/_build/html"

--- a/.github/workflows/trigger-book-build.yaml
+++ b/.github/workflows/trigger-book-build.yaml
@@ -8,5 +8,5 @@ jobs:
     with:
       environment_name: leap-docs-env
       artifact_name: book-zip-${{ github.event.number }}
-      path_to_notebooks: 'book'
+      path_to_notebooks: 'book' 
       # Other input options are possible, see ProjectPythia/cookbook-actions/.github/workflows/build-book.yaml

--- a/.github/workflows/trigger-preview.yaml
+++ b/.github/workflows/trigger-preview.yaml
@@ -13,11 +13,14 @@ jobs:
   deploy-preview:
     needs: find-pull-request
     if: github.event.workflow_run.conclusion == 'success'
-    uses: ProjectPythia/cookbook-actions/.github/workflows/deploy-book.yaml@main
+    # uses: ProjectPythia/cookbook-actions/.github/workflows/deploy-book.yaml@main
+    # for testing
+    uses: jbusecke/cookbook-actions/.github/workflows/deploy-book.yaml@patch-3
     with:
       artifact_name: book-zip-${{ needs.find-pull-request.outputs.number }}
       destination_dir: _preview/${{ needs.find-pull-request.outputs.number }} # deploy to subdirectory labeled with PR number
       is_preview: 'true'
+      publish_dir: "book/_build/html"
       # cname: foundations.projectpythia.org
 
   preview-comment:

--- a/book/leap-pangeo/jupyterhub.md
+++ b/book/leap-pangeo/jupyterhub.md
@@ -1,4 +1,4 @@
-# LEAP-Pangeo JupyterHub
+# LEAP-Pangeo JupyterHub 🚀
 
 Our team has a cloud-based [JupyterHub](https://jupyter.org/hub).
 For information who can access the hub with which privileges, please refer to


### PR DESCRIPTION
#36 did not properly deploy the website. I am pretty sure the issue is our nested book/build dir structure. 
The deployment action silently fails to copy the content of the build dir [here](https://github.com/leap-stc/leap-stc.github.io/actions/runs/4579478140/jobs/8087322290#step:5:45)

This PR bases the cookbook action on my [PR](https://github.com/ProjectPythia/cookbook-actions/pull/45) that adds input to accomodate this structure.