### PR TITLE
Clarify recursive delete for zarr stores

### DIFF
--- a/book/leap-pangeo/jupyterhub.md
+++ b/book/leap-pangeo/jupyterhub.md
@@ -194,14 +194,12 @@ fs.rm('leap-persistent/funky-user/file_to_delete.nc')
 ```
 
 If you want to remove zarr stores (which are an 'exploded' data format, and thus represented by a folder structure) you have to recursively delete the store. 
-:::{warning}
-The warning from above is even more important here! Make sure that the folder you are deleting does not contain any data you do not want to delete!
-:::
 ```python
 fs.rm('leap-scratch/funky-user/processed_store.zarr', recursive=True)
 ```
-
-
+:::{warning}
+The warning from above is even more important here! Make sure that the folder you are deleting does not contain any data you do not want to delete!
+:::
 
 
 


### PR DESCRIPTION
Moving the warning further down to avoid breaking the flow of reading for users.