### PR TITLE
Add team onboarding guide

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -22,5 +22,6 @@ parts:
   - caption: Miscellaneous
     chapters:
       - file: support
+      - file: team_docs
       - file: how_to_cite
       - file: references

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -19,9 +19,9 @@ parts:
   - caption: Guides
     chapters:
       - file: guides/education
+      - file: guides/team_docs
   - caption: Miscellaneous
     chapters:
       - file: support
-      - file: team_docs
       - file: how_to_cite
       - file: references

--- a/book/guides/team_docs.md
+++ b/book/guides/team_docs.md
@@ -8,11 +8,11 @@ This is a short write up facilitate the spin up of new team members for the Data
 - [ ] Make a PR to the `_config.yaml` file [here](https://github.com/leap-stc/leap-stc.github.io/blob/fd69890ffc2f1871968e39b1c460370a0b3f98b3/book/_config.yml#L40-L51) in a PR. to add a picture and your personal data to the webpage.
 
 (onboarding.slack)=
-## Relevant slack channels
-- `data-and-computation-team`: Private channel for internal discussions, please contact the Manager for Data and Computing to be added.
-- `leap-pangeo`: Community wide channel where LEAP-Pangeo users can ask questions. Members of the team should join the channel and regularly engage with issues raised.
+## Relevant channels
+- [`data-and-computation-team`](https://leap-nsf-stc.slack.com/archives/C065KPT1S4Q): Private channel for internal discussions, please contact the Manager for Data and Computing to be added.
+- [`leap-pangeo`](https://leap-nsf-stc.slack.com/archives/C02KB0DDB6E): Community wide channel where LEAP-Pangeo users can ask questions. Members of the team should join the channel and regularly engage with issues raised.
 
 (onboarding.github)=
 ## Relevant github repos
 - [`leap-stc.github.io`](https://github.com/leap-stc/leap-stc.github.io): The source for the [LEAP-Pangeo technical documentation](https://leap-stc.github.io/intro.html). This also contains [LEAP-Pangeo Discussion Forum](https://github.com/leap-stc/leap-stc.github.io/discussions)
-- [data-management](https://github.com/leap-stc/data-management): Contains all the [pangeo-forge](https://pangeo-forge.readthedocs.io/en/latest/) based code/automation to ingest new datasets. Point users to the [issue tracker](https://github.com/leap-stc/data-management/issues/new/choose) to request new datasets.
+- [`data-management`](https://github.com/leap-stc/data-management): Contains all the [pangeo-forge](https://pangeo-forge.readthedocs.io/en/latest/) based code/automation to ingest new datasets. Point users to the [issue tracker](https://github.com/leap-stc/data-management/issues/new/choose) to request new datasets.

--- a/book/support.rst
+++ b/book/support.rst
@@ -3,7 +3,7 @@ Support
 
 .. _support.data_compute_team:
 
-Data and Compute Team
+Data and Computation Team
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. jinja:: team-data

--- a/book/team_docs.md
+++ b/book/team_docs.md
@@ -1,0 +1,18 @@
+# Onboarding Guide for Data and Computation Team Members
+
+This is a short write up facilitate the spin up of new team members for the Data and Computation Team.
+
+## Checklist for new members
+- Subscribe to [](onboarding.slack)
+- Consider enabling notifications for [](onboarding.github)
+- Make a PR to the `_config.yaml` file [here](https://github.com/leap-stc/leap-stc.github.io/blob/fd69890ffc2f1871968e39b1c460370a0b3f98b3/book/_config.yml#L40-L51) in a PR. to add a picture and your personal data to the webpage.
+
+(onboarding.slack)=
+## Relevant slack channels
+- `data-and-computation-team`: Private channel for internal discussions, please contact the Manager for Data and Computing to be added.
+- `leap-pangeo`: Community wide channel where LEAP-Pangeo users can ask questions. Members of the team should join the channel and regularly engage with issues raised.
+
+(onboarding.github)=
+## Relevant github repos
+- [`leap-stc.github.io`](https://github.com/leap-stc/leap-stc.github.io): The source for the [LEAP-Pangeo technical documentation](https://leap-stc.github.io/intro.html). This also contains [LEAP-Pangeo Discussion Forum](https://github.com/leap-stc/leap-stc.github.io/discussions)
+- [data-management](https://github.com/leap-stc/data-management): Contains all the [pangeo-forge](https://pangeo-forge.readthedocs.io/en/latest/) based code/automation to ingest new datasets. Point users to the [issue tracker](https://github.com/leap-stc/data-management/issues/new/choose) to request new datasets.

--- a/book/team_docs.md
+++ b/book/team_docs.md
@@ -3,9 +3,9 @@
 This is a short write up facilitate the spin up of new team members for the Data and Computation Team.
 
 ## Checklist for new members
-- Subscribe to [](onboarding.slack)
-- Consider enabling notifications for [](onboarding.github)
-- Make a PR to the `_config.yaml` file [here](https://github.com/leap-stc/leap-stc.github.io/blob/fd69890ffc2f1871968e39b1c460370a0b3f98b3/book/_config.yml#L40-L51) in a PR. to add a picture and your personal data to the webpage.
+- [ ] Subscribe to [](onboarding.slack)
+- [ ] Consider enabling notifications for [](onboarding.github)
+- [ ] Make a PR to the `_config.yaml` file [here](https://github.com/leap-stc/leap-stc.github.io/blob/fd69890ffc2f1871968e39b1c460370a0b3f98b3/book/_config.yml#L40-L51) in a PR. to add a picture and your personal data to the webpage.
 
 (onboarding.slack)=
 ## Relevant slack channels


### PR DESCRIPTION
I just went through a very helpful dicsussion with @SammyAgrawal and wanted to add an onboarding guide for Data and Compute Team members here to be able to point to. 