### PR TITLE
Raise on warnings during CI

### DIFF
--- a/.github/workflows/trigger-book-build.yaml
+++ b/.github/workflows/trigger-book-build.yaml
@@ -9,4 +9,5 @@ jobs:
       environment_name: leap-docs-env
       artifact_name: book-zip-${{ github.event.number }}
       path_to_notebooks: "book"
+      build_command: "jupyter-book build -W --keep-going ."
       # Other input options are possible, see ProjectPythia/cookbook-actions/.github/workflows/build-book.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ coverage.xml
 
 book/_build/
 
+.vscode/settings.json

--- a/book/guides/education.md
+++ b/book/guides/education.md
@@ -4,7 +4,7 @@
 
 🚧 Full Guide coming soon ... If you are a LEAP educator and want to run your class on the hub, please reach out to the [](support.data_compute_team).
 
-(education:sing_up)=
+(education.sing_up)=
 ### How to sign up students
 
 Students should be signed up to the appropriate user [categories](users.categories) ahead of the class. Please direct your students to this documentation and try to ensure that everyone has [access to the Hub](hub:server:login) before the class starts.
@@ -13,17 +13,17 @@ Students should be signed up to the appropriate user [categories](users.categori
 
 **Students cannot sign on**
 
-Check if the students are part of the [appropriate github teams](users:categories). 
+Check if the students are part of the [appropriate github teams](users.categories). 
 
 If they **are not** follow these steps:
-- [ ] Did the student [sign up for LEAP membership]()?
-- [ ] Did the student receive a github invite? [Here](users.invite) is how to check for that.  
-- [ ] Check again if they are part of the [appropriate github teams](users:categories).
-- If these steps do not work, please reach out to [](contact.data_compute_manager).
+- [ ] Did the student [sign up for LEAP membership](users.membership.apply)?
+- [ ] Did the student receive a github invite? [Here](users.membership.invite) is how to check for that.  
+- [ ] Check again if they are part of the [appropriate github teams](users.categories).
+- If these steps do not work, please reach out to the [](support.data_compute_team).
 
 If they **are**, ask them to try the following steps:
 - [ ] Refresh the browser cache
 - [ ] Try a different browser
 - [ ] Restart the computer
-- If these steps do not work, please reach out to [](contact.data_compute_manager).
+- If these steps do not work, please reach out to the [](support.data_compute_team).
 

--- a/book/guides/hub_guides.md
+++ b/book/guides/hub_guides.md
@@ -18,11 +18,12 @@ We distinguish between two primary *types* of data to upload: "Original" and "Pu
 - **Published Data** has been published and archived in a publically accessible location (e.g. a data repository like [zenodo](https://zenodo.org) or [figshare](https://figshare.com)). We do not recommend uploading this data to the cloud directly, but instead use [Pangeo Forge](https://pangeo-forge.readthedocs.io/en/latest/) to transform and upload it to the cloud. This ensures that the data is stored in an ARCO format and can be easily accessed by other LEAP members.
 - **Original Data** is any dataset that is produced by researchers at LEAP and has not been published yet. The main use case for this data is to share it with other LEAP members and collaborate on it. For original data we support direct uploaded to the cloud. *Be aware that original data could change rapidly as the data producer is iterating on their code*. We encourage all datasets to be archived and published before using them in scientific publications.  
 
-##### Transform and Upload published data to an ARCO format (with Pangeo Forge)
+#### Transform and Upload published data to an ARCO format (with Pangeo Forge)
 
 Coming Soon
 
-##### Upload medium sized original data from your local machine
+(hub.guide.data.upload_manual)=
+#### Upload medium sized original data from your local machine
 
 For medium sized datasets, that can be uploaded within an hour, you can use a temporary access token generated on the JupyterHub to upload data to the cloud.
 
@@ -40,7 +41,7 @@ conda activate leap_pange_transfer
 
 and set up a jupyter notbook (or a pure python script) that loads your data in as few xarray datasets as possible. For instance, if you have one dataset that consists of many files split in time, you should set your notebook up to read all the files using xarray into a single dataset, and then try to write out a small part of the dataset to a zarr store.
 
-- Now start up a [LEAP-Pangeo server](leap.2i2c.cloud) and open a terminal. Install the [Google Cloud SDK](https://cloud.google.com/sdk/docs/install) using mamba
+- Now start up a [LEAP-Pangeo server](https://leap.2i2c.cloud) and open a terminal. Install the [Google Cloud SDK](https://cloud.google.com/sdk/docs/install) using mamba
 
 ```shell
 mamba install google-cloud-sdk
@@ -82,15 +83,15 @@ ds.to_zarr('gs://leap-scratch/<your_username>/test_offsite_upload.zarr') #adding
 
 > Replace `<your_username>` with your actual username on the hub.
 
-- Make sure that you can read the test dataset from within the hub (go back to [Basic writing to and reading from cloud buckets](hub:data:read_write)).
+- Make sure that you can read the test dataset from within the hub (go back to [Basic writing to and reading from cloud buckets](hub.data.read_write)).
 
 - Now the last step is to paste the code to load your actual dataset into the notebook and use `.to_zarr` to upload it.
 
 > Make sure to give the store a meaningful name, and raise an issue in the [data-management repo](https://github.com/leap-stc/data-management/issues) to get the dataset added to the LEAP Data Library.
 
-> Make sure to use a different bucket than `leap-scratch`, since that will be deleted every 7 days! For more info refer to the available [storage buckets](hub:data:buckets).
+> Make sure to use a different bucket than `leap-scratch`, since that will be deleted every 7 days! For more info refer to the available [storage buckets](hub.data.buckets).
 
-(hub:data:upload_hpc)=
+(hub.data.upload_hpc)=
 ##### Uploading large original data from an HPC system (no browser access on the system available) 
 
 A commong scenario is the following: A researcher/student has run a simulation on a High Performance Computer (HPC) at their institution, but now wants to collaboratively work on the analysis or train a machine learning model with this data. For this they need to upload it to the cloud storage.

--- a/book/how_to_cite.md
+++ b/book/how_to_cite.md
@@ -2,7 +2,7 @@
 
 If you use any of the LEAP resources, please follow these guidlines to recognize our work.
 
-## Add your publication to our [LEAP publication tracker]()
+## Add your publication to our [LEAP publication tracker](https://docs.google.com/spreadsheets/d/1zVfivXK-GKLEma_uc-SAIRs7OP_qfTUmsypAQeVqstI/edit#gid=645657151)
 
 ## Cite LEAP-Pangeo Platform
 If you used the JupyterHub platform to perform analysis, please add a statement similar to this to your acknowledgment section of the paper:

--- a/book/leap-pangeo/jupyterhub.md
+++ b/book/leap-pangeo/jupyterhub.md
@@ -14,14 +14,14 @@ For information who can access the hub with which privileges, please refer to
 This document goes over the primary technical details of the JupyterHub. 
 - For a quick tutorial on basic usage, please see [Getting Started](tutorial.md). 
 - To get an in-depth overview of the LEAP Pangeo Architecture and how the JupyterHub fits into it, please see the [Architecture](architecture.md) page.
-### The Software Environment
+## The Software Environment
 The software environment you encounter on the Hub is based upon [docker images](https://www.digitalocean.com/community/tutorials/the-docker-ecosystem-an-introduction-to-common-components) which you can run on other machines (like your laptop or an HPC cluster) for better reproducibility.
 
 Upon start up you can choose between
 - A list of preselected images
 - The option of passing a custom docker image via the `"Other..."` option.
 
-#### Preselected Images
+### Preselected Images
 LEAP-Pangeo uses several full-featured, up-to-date Python environments maintained by Pangeo. You can read all about them at the following URL:
 
 - https://github.com/pangeo-data/pangeo-docker-images/
@@ -37,24 +37,24 @@ A complete list of all packages installed in this environment is located at:
 :::{attention}
 We regularly update the version of the images provided in the drop-down menu. 
 
-To ensure full reproducibility you should save the full info of the image you worked with (this is stored in the environment variable `JUPYTER_IMAGE_SPEC`) with your work. You can then use that string with the [custom images](hub:image:custom) to reproduce your work with exactly the same environment.
+To ensure full reproducibility you should save the full info of the image you worked with (this is stored in the environment variable `JUPYTER_IMAGE_SPEC`) with your work. You can then use that string with the [custom images](hub.image.custom) to reproduce your work with exactly the same environment.
 :::
 
-(hub:image:custom)=
-#### Custom Images
+(hub.image.custom)=
+### Custom Images
 
 If you select the `Image > Other...` Option during [server login](hub:server:login) you can paste an arbitrary reference in the form of `docker_registry/organization/image_name:image_version`. As an example we can get the `2023.05.08` version of the pangeo tensorflow notebook by pasting `quay.io/pangeo/ml-notebook:2023.05.08`.
 
 If you want to build your own docker image for your project, take a look at [this template](https://github.com/2i2c-org/hub-user-image-template) and the instructions to learn how to use [repo2docker](https://github.com/jupyterhub/repo2docker) to set up CI workflows to automatically build docker images from your repository.
 
-#### Installing additonal packages
+### Installing additonal packages
 
 You can install additional packages using `pip` and `conda`.
 However, these will disappear when your server shuts down. 
 
-For a more permanent solution we recommend building project specific dockerfiles and using those as [custom images](hub:image:custom).
+For a more permanent solution we recommend building project specific dockerfiles and using those as [custom images](hub.image.custom).
 
-### Files and Data
+## Files and Data
 
 Data and files work differently in the cloud. 
 To help onboard you to this new way of working, we have written a guide to Files and Data in the Cloud:
@@ -63,8 +63,8 @@ To help onboard you to this new way of working, we have written a guide to Files
 
 We recommend you read this thoroughly, especially the part about Git and GitHub.
 
-(hub:data:user_dir)=
-#### Your User Directory
+(hub.guide.data.user_dir)=
+### Your User Directory
 
 When you open your hub, you can navigate to the "File Browser" and see all the files in your User Directory
 <img width="442" alt="image" src="https://github.com/leap-stc/leap-stc.github.io/assets/14314623/3ba6b45a-a077-4824-b0ec-9c111af50c33">
@@ -85,22 +85,22 @@ Please do not store large files in your user directory `/home/jovyan`. Your home
 To check how much space you are using in your home directory open a terminal window on the hub and run `du -h --max-depth=1 ~/ | sort -h`.
 :::
 
-(hub:data:buckets)=
-#### LEAP-Pangeo Buckets
+(hub.data.buckets)=
+### LEAP-Pangeo Buckets
 
 LEAP-Pangeo provides users two cloud buckets to store data
 
 - `gs://leap-scratch/` - Temporary Storage deleted after 7 days. Use this bucket for testing and storing large intermediate results. [More info](https://docs.2i2c.org/user/topics/data/cloud/#scratch-bucket) 
 - `gs://leap-persistent` - Persistent Storage. Use this bucket for storing results you want to share with other members.
-- `gs://leap-persistent-ro` - Persistent Storage with read-only access for most users. To upload data to this bucket you need to use [this](hub:data:upload_hpc) method below.
+- `gs://leap-persistent-ro` - Persistent Storage with read-only access for most users. To upload data to this bucket you need to use [this](hub.data.upload_hpc) method below.
 
 Files stored on each of those buckets can be accessed by any LEAP member, so be concious in the way you use these.
 
 - **Do not put sensitive information (passwords, keys, personal data) into these buckets!**
 - **When writing to buckets only ever write to your personal folder!** Your personal folder is a combination of the bucketname and your github username (e.g. `gs://leap-persistent/funky-user/').
 
-(hub:data:list)=
-#### Inspecting contents of the bucket
+(hub.data.list)=
+### Inspecting contents of the bucket
 
 We recommend using [gcsfs](https://gcsfs.readthedocs.io/en/latest/) or [fsspec](https://filesystem-spec.readthedocs.io/en/latest/) which provide a filesytem-like interface for python.
 
@@ -111,8 +111,8 @@ fs = gcsfs.GCSFileSystem() # equivalent to fsspec.fs('gs')
 fs.ls('leap-persistent/funky-user')
 ```
 
-(hub:data:read_write)=
-#### Basic writing to and reading from cloud buckets
+(hub.data.read_write)=
+### Basic writing to and reading from cloud buckets
 
 We do not recommend uploading large files (e.g. netcdf) directly to the bucket. Instead we recommend to write data as ARCO (Analysis-Ready Cloud-Optimized) formats like [zarr](https://zarr.dev)(for n-dimensional arrays) and [parquet](https://parquet.apache.org)(for tabular data) (read more [here](https://ieeexplore.ieee.org/document/9354557) why we recommend ARCO formats).
 
@@ -138,7 +138,7 @@ ds = xr.open_dataset('gs://leap-scratch/funky-user/processed_store.zarr', engine
 ... and you can give this to any other registered LEAP user and they can load it exactly like you can! 
 
 :::{note}
-Note that providing the url starting with `gs://...` is assumes that you have appropriate credentials set up in your environment to read/write to that bucket. On the hub these are already set up for you to work with the [](hub:data:buckets), but if you are trying to interact with non-public buckets you need to authenticate yourself. Check out the sections [below](hub:data:upload_manual) to see an example how to do that.
+Note that providing the url starting with `gs://...` is assumes that you have appropriate credentials set up in your environment to read/write to that bucket. On the hub these are already set up for you to work with the [](hub.data.buckets), but if you are trying to interact with non-public buckets you need to authenticate yourself. Check out the sections [below](hub.guide.data.upload_manual) to see an example how to do that.
 :::
 
 
@@ -148,9 +148,10 @@ with fsspec.open('gs://leap-scratch/funky-user/test.txt', mode='w') as f:
     f.write('hello world')
 ```
 
-#### Deleting from cloud buckets
+### Deleting from cloud buckets
+
 :::{warning}
-Depending on which cloud bucket you are working, make sure to double check which files you are deleting by [inspecting the contents](hub:data:list) and only working in a subdirectory with your username (e.g. `gs://<leap-bucket>/<your-username>/some/project/structure`.
+Depending on which cloud bucket you are working, make sure to double check which files you are deleting by [inspecting the contents](hub.data.list) and only working in a subdirectory with your username (e.g. `gs://<leap-bucket>/<your-username>/some/project/structure`.
 :::
 
 You can remove single files by using a gcsfs/fsspec filessytem as above

--- a/book/leap-pangeo/tutorial.md
+++ b/book/leap-pangeo/tutorial.md
@@ -6,7 +6,7 @@ To get started using the hub, check out this video by [James Munroe](https://git
 
 
 ## How can I get access to the Hub
-Only LEAP members will be able to access the hub. Please [become a member](users:membership:apply) and make sure you accept the [invitation on github](users:membership:invite) before proceeding
+Only LEAP members will be able to access the hub. Please [become a member](users.membership.apply) and make sure you accept the [invitation on github](users.membership.invite) before proceeding
 
 ## Hub Usage
 
@@ -25,7 +25,7 @@ Feel free to [edit it yourself](https://github.com/leap-stc/leap-stc.github.io/b
 
 <img width="410" alt="image" src="https://github.com/leap-stc/leap-stc.github.io/assets/14314623/088946a1-896f-4ff8-af91-8107c9f14cfd">
 
-> Note: Depending on your [membership]() you might see additional options (e.g. for GPU machines)
+> Note: Depending on your [membership](users.membership) you might see additional options (e.g. for GPU machines)
 
 You have to make 3 choices here:
 - The machine type (Choose between "CPU only" or "GPU" if available)

--- a/book/policies/users_roles.md
+++ b/book/policies/users_roles.md
@@ -1,4 +1,4 @@
-(users:categories)=
+(users.categories)=
 # Users and Categories
 
 **Version 2 - 2022-10-25**
@@ -26,13 +26,14 @@ All users of LEAP-Pangeo must abide by the LEAP Code of Conduct:
 
 - https://docs.google.com/document/d/1eE-aYrsf_k5Ep8GB-n8hmqM_LVW-U3uzYKHJBZMvYWU
 
+(users.membership)=
 ## Membership
 
 LEAP members are grouped into the following member tiers.
 
 ### Tier 1 Members
 
-Tier 1 members have access to [storage](hub:data:buckets) and computing resource up to 4 cores and 32GB RAM on JupyterHub servers
+Tier 1 members have access to [storage](hub.data.buckets) and computing resource up to 4 cores and 32GB RAM on JupyterHub servers
 in the LEAP-Pangeo Hub.
 
 Tier 1 membership is granted by adding the user to the [`leap-pangeo-base-access`](https://github.com/orgs/leap-stc/teams/leap-pangeo-base-access) GitHub Team.
@@ -104,9 +105,6 @@ team for the course and add the instructor as a "Maintainer".
 It is the instructor's responsibility to add the course's users to this team
 and remove them when the course has been concluded.
 
-
-
-
 ### Research Category
 
 The education category is intended for _long-term access_ to LEAP-Pangeo resources associated
@@ -139,12 +137,12 @@ It is the PIs' responsibility to add and remove members from their team.
 The LEAP Director of Data and Computing or the LEAP Manager of Data and Computing may grant access to other participants for
 the purposes of technical development, debugging, and evaluation of the platform. These members will be added to the [`leap-pangeo-full-access`](https://github.com/orgs/leap-stc/teams/leap-pangeo-full-access) team to have full access to all resources.
 
-(users:membership:apply)=
+(users.membership.apply)=
 ### Applying for membership
 
 To become a LEAP member please refer to the [Research Membership Structure](https://leap.columbia.edu/about/policies2/) on the LEAP website.
 
-(users:membership:invite)=
+(users.membership.invite)=
 ### "Where is my invite?"
 
 Please check your email account (**the one you used to sign up for Github** - this is independent of the email you use for LEAP) for an invite that will look similar to this:

--- a/book/support.rst
+++ b/book/support.rst
@@ -17,57 +17,56 @@ Data and Computation Team
 
 .. jinja:: team-data
 
-    {% for person in people %}
+  {% for person in people %}
 
-    {{ person.name }} ({{ person.org }})
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  {{ person.name }} ({{ person.org }})
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    {% if person.role %}
-    {{ person.role }}
-    {% endif %}
+  {% if person.role %}
+  {{ person.role }}
+  {% endif %}
+  {% if person.pic %}
+  .. image:: images/{{ person.pic }}
+     :width: 200px
+     :alt: {{ person.name }}
+     :class: biopic
+  {% endif %}
+  |
+  {% if person.slack_id %}
+  .. image:: https://img.shields.io/static/v1?label=&message=Slack&color=0077B5&style=flat-square&logo=slack
+      :alt: Slack DM
+      :target: https://leap-nsf-stc.slack.com/team/{{ person.slack_id }}
+  
+  {% endif %}
 
-    {% if person.slack_id %}
-    .. image:: https://img.shields.io/static/v1?label=&message=Slack&color=0077B5&style=flat-square&logo=slack
-        :alt: Slack DM
-        :target: https://leap-nsf-stc.slack.com/team/{{ person.slack_id }}
-    
-    {% endif %}
+  {% if person.pronouns %}
+  .. image:: https://img.shields.io/static/v1?label=pronouns&message={{ person.pronouns }}&color=red&style=flat-square
+     :alt: Pronouns
+  {% endif %}
 
-    {% if person.pic %}
-    .. image:: images/{{ person.pic }}
-       :width: 200px
-       :alt: {{ person.name }}
-       :class: biopic
-    {% endif %}
+  {% if person.github %}
+  .. image:: https://img.shields.io/github/followers/{{ person.github }}?label=Github&logo=github&style=flat-square
+     :alt: GitHub Profile
+     :target: http://github.com/{{ person.github }}
+  {% endif %}
 
-    {% if person.pronouns %}
-    .. image:: https://img.shields.io/static/v1?label=pronouns&message={{ person.pronouns }}&color=red&style=flat-square
-       :alt: Pronouns
-    {% endif %}
+  {% if person.twitter %}
+  .. image:: https://img.shields.io/twitter/follow/{{ person.twitter }}?logo=twitter&style=flat-square
+      :alt: Twitter
+      :target: https://twitter.com/{{ person.twitter }}
+  {% endif %}
 
-    {% if person.github %}
-    .. image:: https://img.shields.io/github/followers/{{ person.github }}?label=Github&logo=github&style=flat-square
-       :alt: GitHub Profile
-       :target: http://github.com/{{ person.github }}
-    {% endif %}
+  {% if person.linkedin %}
+  .. image:: https://img.shields.io/static/v1?label=&message=LinkedIn&color=0077B5&style=flat-square&logo=linkedin
+     :alt: Google Scholar
+     :target: https://www.linkedin.com/in/{{ person.linkedin }}
+  {% endif %}
 
-    {% if person.twitter %}
-    .. image:: https://img.shields.io/twitter/follow/{{ person.twitter }}?logo=twitter&style=flat-square
-        :alt: Twitter
-        :target: https://twitter.com/{{ person.twitter }}
-    {% endif %}
+  {% if person.website %}
+  .. image:: https://img.shields.io/website?style=flat-square&url={{ person.website|urlencode }}
+      :alt: Website
+      :target: {{ person.website }}
+  {% endif %}
 
-    {% if person.linkedin %}
-    .. image:: https://img.shields.io/static/v1?label=&message=LinkedIn&color=0077B5&style=flat-square&logo=linkedin
-       :alt: Google Scholar
-       :target: https://www.linkedin.com/in/{{ person.linkedin }}
-    {% endif %}
-
-    {% if person.website %}
-    .. image:: https://img.shields.io/website?style=flat-square&url={{ person.website|urlencode }}
-        :alt: Website
-        :target: {{ person.website }}
-    {% endif %}
-
-    {{ person.bio }}
-    {% endfor %}
+  {{ person.bio }}
+  {% endfor %}

--- a/book/support.rst
+++ b/book/support.rst
@@ -1,5 +1,5 @@
 Getting Help
-=======
+============
 
 For questions about how to use the Hub, please use the LEAP-Pangeo discussion forum:
 
@@ -13,7 +13,7 @@ You can reserve an appointment `here <https://app.reclaim.ai/m/leap-pangeo-offic
 .. _support.data_compute_team:
 
 Data and Computation Team
-------------
+-------------------------
 
 .. jinja:: team-data
 
@@ -30,7 +30,7 @@ Data and Computation Team
     .. image:: https://img.shields.io/static/v1?label=&message=Slack&color=0077B5&style=flat-square&logo=slack
         :alt: Slack DM
         :target: https://leap-nsf-stc.slack.com/team/{{ person.slack_id }}
-    |
+    
     {% endif %}
 
     {% if person.pic %}
@@ -40,7 +40,7 @@ Data and Computation Team
        :class: biopic
     {% endif %}
 
-    |{% if person.pronouns %}
+    {% if person.pronouns %}
     .. image:: https://img.shields.io/static/v1?label=pronouns&message={{ person.pronouns }}&color=red&style=flat-square
        :alt: Pronouns
     {% endif %}


### PR DESCRIPTION
This will ensure that missing references etc are detected as part of the CI

By changing the execution command to `jupyter-book build -W --keep-going .` we fail on warnings, but also list all of the warnings with the output in the log.

This PR includes:
- homogenization of reference style from e.g. `hub:data` to `hub.data`
- Fixes necessary to make the build pass without any warnings.