### PR TITLE
Ci link checking

### DIFF
--- a/book/leap-pangeo/architecture.md
+++ b/book/leap-pangeo/architecture.md
@@ -172,7 +172,7 @@ It’s useful to understand the recent history and related efforts in this space
 - **[Google Earth Engine](https://earthengine.google.org/)** is a reference point for all cloud geospatial analytics platforms.
   It’s actually a standalone application that is separate from Google Cloud, the single instance of a highly customized, black box (i.e. not open source)  application that enables parallel computing on distributed data.
   It’s very good at what it was designed for (analyzing satellite images), but isn’t easily adapted to other applications, such as machine learning.
-- **[Columbia IRI Data Library](https://iridl.ldeo.columbia.edu/index.html)** is a powerful and freely accessible online data repository and analysis tool that allows a user to view, analyze, and download hundreds of terabytes of climate-related data through a standard web browser.
+- **[Columbia IRI Data Library](https://iridl.ldeo.columbia.edu/)** is a powerful and freely accessible online data repository and analysis tool that allows a user to view, analyze, and download hundreds of terabytes of climate-related data through a standard web browser.
   Due to its somewhat outdated architecture, IRI data library cannot easily be updated or adapted to new projects.
 - **[Pangeo](http://pangeo.io/)** is an open science community oriented around open-source python tools for big-data geoscience.
   It is a loose ecosystem of interoperable python packages including [Jupyter](https://jupyter.org/), [Xarray](http://xarray.pydata.org/), [Dask](http://dask.pydata.org/), and [Zarr](https://zarr.readthedocs.io/).
@@ -181,7 +181,7 @@ It’s useful to understand the recent history and related efforts in this space
   Pangeo is used heavily within NCAR.
 - **[Microsoft Planetary Computer](https://planetarycomputer.microsoft.com/)** is a collection of datasets and computational tools hosted by Microsoft in the Azure cloud.
   It combines Pangeo-style computing environments with a data library based on [SpatioTemporal Asset Catalog](https://stacspec.org/)
-- **[Radiant Earth ML Hub](https://www.radiant.earth/mlhub/)** is a cloud-based open library dedicated to Earth observation training data for use with machine learning algorithms.
+- **[Source Cooperative (formerly Radiant Earth ML Hub)](https://source.coop)** is a cloud-based open library dedicated to Earth observation training data for use with machine learning algorithms.
   It focuses mostly on data access and curation.
   Data are cataloged using STAC.
 - **[Pangeo Forge](https://pangeo-forge.org/)** is a new initiative, funded by the NSF EarthCube program, to build a platform for

--- a/book/leap-pangeo/solutions.md
+++ b/book/leap-pangeo/solutions.md
@@ -27,4 +27,4 @@ client = cluster.get_client()
 ```
 <!-- TODO: Add example how to change this in HTML repr -->
 
-[Example with Solution](https://notebooksharing.space/view/2b6753a5ffe8ddfae1da3b8e2b5507e617de47eb25f758a20c92b62e7e650fd7#displayOptions=)
+[Example with Solution](https://notebooksharing.space/view/2b6753a5ffe8ddfae1da3b8e2b5507e617de47eb25f758a20c92b62e7e650fd7)

--- a/book/policies/users_roles.md
+++ b/book/policies/users_roles.md
@@ -3,7 +3,7 @@
 
 **Version 2 - 2022-10-25**
 
-Access to the LEAP-Pangeo Hub will depend on the [LEAP Membership Structure](https://leap.columbia.edu/wp-content/uploads/2022/09/LEAP-Membership-and-Space-Policy-Sept-2022.pdf) (see links in this document to apply for membership).
+Access to the LEAP-Pangeo Hub will depend on the [LEAP Membership Structure](https://leap.columbia.edu/about/policies2/) (see links in this document to apply for membership).
 Membership in a particular tier will be implemented via
 [GitHub Teams](https://docs.github.com/en/organizations/organizing-members-into-teams)
 in the [leap-stc](https://github.com/orgs/leap-stc/teams) GitHub organization.

--- a/book/references.bib
+++ b/book/references.bib
@@ -20,9 +20,7 @@
 	number = {2},
 	pages = {e2020AV000354},
 	keywords = {cloud computing, inclusivity, interoperability, open access, open data, open science},
-	doi = {https://doi.org/10.1029/2020AV000354},
-	url = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2020AV000354},
-	eprint = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2020AV000354},
+	doi = {10.1029/2020AV000354},
 	note = {e2020AV000354 2020AV000354},
 	year = {2021}
 }


### PR DESCRIPTION
An attempt towards #119

This currently just includes a bunch of link fixes. I am planning to run `jupyter-book build -W --keep-going book/ --builder linkcheck` as part of the CI, but I am getting weird results: 

```
(leap-pangeo/architecture: line   52) broken    https://www.openstoragenetwork.org/ - HTTPSConnectionPool(host='www.openstoragenetwork.org', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1006)')))
```

navigating to https://www.openstoragenetwork.org/ works without problems. There are other similar errors for the iridl links...as longs as we cannot fix these issues I am hesitant to run this as part of the CI, since it will fail all the time. 



