### PR TITLE
Add FAQ and move troubleshooting steps from edu guide

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -16,6 +16,7 @@ parts:
       - file: leap-pangeo/solutions
       - file: guides/education
       - file: guides/team_docs
+      - file: guides/faq
   - caption: Policies
     chapters:
       - file: policies/code_policy

--- a/book/guides/education.md
+++ b/book/guides/education.md
@@ -11,19 +11,6 @@ Students should be signed up to the appropriate user [categories](users.categori
 
 #### Troubleshooting
 
-**Students cannot sign on**
+##### Students cannot sign on
 
-Check if the students are part of the [appropriate github teams](users.categories). 
-
-If they **are not** follow these steps:
-- [ ] Did the student [sign up for LEAP membership](users.membership.apply)?
-- [ ] Did the student receive a github invite? [Here](users.membership.invite) is how to check for that.  
-- [ ] Check again if they are part of the [appropriate github teams](users.categories).
-- If these steps do not work, please reach out to the [](support.data_compute_team).
-
-If they **are**, ask them to try the following steps:
-- [ ] Refresh the browser cache
-- [ ] Try a different browser
-- [ ] Restart the computer
-- If these steps do not work, please reach out to the [](support.data_compute_team).
-
+Please refer to the [FAQ](faq.cannot-log-into-hub) for troubleshooting steps.

--- a/book/guides/faq.md
+++ b/book/guides/faq.md
@@ -1,0 +1,20 @@
+# Frequently asked questions
+
+(faq.cannot-log-into-hub)=
+## I cannot log into the hub 😱
+
+If you are unable to log into the hub, please check the following steps:
+
+- [ ] Check if you are member of the [appropriate github teams](users.categories).
+
+If you **are not** follow these steps:
+- [ ] Did you [sign up for LEAP membership](users.membership.apply)? This will be done for you if you sign up for an event like the Momentum bootcamp!
+- [ ] Did you receive a github invite? [Here](users.membership.invite) is how to check for that.  
+- [ ] Check again if they are part of the [appropriate github teams](users.categories).
+- If these steps do not work, please reach out to the [](support.data_compute_team).
+
+If you **are** member of one of the github teams, ask them to try the following steps:
+- [ ] Refresh the browser cache
+- [ ] Try a different browser
+- [ ] Restart the computer
+- If these steps do not work, please reach out to the [](support.data_compute_team).

--- a/book/guides/faq.md
+++ b/book/guides/faq.md
@@ -1,4 +1,4 @@
-# Frequently asked questions
+# FAQs
 
 (faq.cannot-log-into-hub)=
 ## I cannot log into the hub 😱


### PR DESCRIPTION
The sign on troubleshooting is very often useful, so we should put it in a central place to link to it.