### PR TITLE
Add Admin tasks + Software env update docs to team guide

### DIFF
--- a/book/guides/team_docs.md
+++ b/book/guides/team_docs.md
@@ -1,8 +1,19 @@
-# Onboarding Guide for Data and Computation Team Members
+# Data and Computation Team Members Guide
 
+## Administrative Tasks
+
+This section documents common tasks performed as part of the Data and Computation Team's duties.
+
+### Regularly Updating the Software Environment
+
+We aim to provide users with [up-to-date default software environments](jupyterhub.software_env). This currently requires to change the [pangeo-docker-images](https://github.com/pangeo-data/pangeo-docker-images) tag manually.
+- Make sure you are subscribed to release notifications on [pangeo-docker-images](https://github.com/pangeo-data/pangeo-docker-images) to recieve Github notification about new releases
+- To bump the version, submit a PR to [this config file](https://github.com/2i2c-org/infrastructure/blob/master/config/clusters/leap/common.values.yaml) in the [2i2c infrastructure repo](https://github.com/2i2c-org/infrastructure). In that PR you need to change the image tag for *all image choices*, see an example [here](https://github.com/2i2c-org/infrastructure/pull/3688).
+
+## Onboarding
 This is a short write up facilitate the spin up of new team members for the Data and Computation Team.
 
-## Checklist for new members
+### Checklist for new members
 - [ ] Ask to be added to the [Data and Computation Github team](https://github.com/orgs/leap-stc/teams/data-team/members)
 - [ ] Ask to be added to the `@data-and-compute` Slack user group
 - [ ] Subscribe to [](onboarding.slack)
@@ -10,11 +21,11 @@ This is a short write up facilitate the spin up of new team members for the Data
 - [ ] Make a PR to the `_config.yaml` file [here](https://github.com/leap-stc/leap-stc.github.io/blob/fd69890ffc2f1871968e39b1c460370a0b3f98b3/book/_config.yml#L40-L51) in a PR. to add a picture and your personal data to the webpage.
 
 (onboarding.slack)=
-## Relevant Slack channels
+### Relevant Slack channels
 - [`data-and-computation-team`](https://leap-nsf-stc.slack.com/archives/C065KPT1S4Q): Private channel for internal discussions, please contact the Manager for Data and Computing to be added.
 - [`leap-pangeo`](https://leap-nsf-stc.slack.com/archives/C02KB0DDB6E): Community wide channel where LEAP-Pangeo users can ask questions. Members of the team should join the channel and regularly engage with issues raised.
 
 (onboarding.github)=
-## Relevant github repos
+### Relevant github repos
 - [`leap-stc.github.io`](https://github.com/leap-stc/leap-stc.github.io): The source for the [LEAP-Pangeo technical documentation](https://leap-stc.github.io/intro.html). This also contains [LEAP-Pangeo Discussion Forum](https://github.com/leap-stc/leap-stc.github.io/discussions)
 - [`data-management`](https://github.com/leap-stc/data-management): Contains all the [pangeo-forge](https://pangeo-forge.readthedocs.io/en/latest/) based code/automation to ingest new datasets. Point users to the [issue tracker](https://github.com/leap-stc/data-management/issues/new/choose) to request new datasets.

--- a/book/guides/team_docs.md
+++ b/book/guides/team_docs.md
@@ -42,5 +42,6 @@ Unfortunately we do not have a technical way to implement per user quotas, so we
 ### Regularly Updating the Software Environment
 
 We aim to provide users with [up-to-date default software environments](jupyterhub.software_env). This currently requires to change the [pangeo-docker-images](https://github.com/pangeo-data/pangeo-docker-images) tag manually.
+
 - Make sure you are subscribed to release notifications on [pangeo-docker-images](https://github.com/pangeo-data/pangeo-docker-images) to recieve Github notification about new releases
 - To bump the version, submit a PR to [this config file](https://github.com/2i2c-org/infrastructure/blob/master/config/clusters/leap/common.values.yaml) in the [2i2c infrastructure repo](https://github.com/2i2c-org/infrastructure). In that PR you need to change the image tag for *all image choices*, see an example [here](https://github.com/2i2c-org/infrastructure/pull/3688).

--- a/book/leap-pangeo/jupyterhub.md
+++ b/book/leap-pangeo/jupyterhub.md
@@ -14,6 +14,8 @@ For information who can access the hub with which privileges, please refer to
 This document goes over the primary technical details of the JupyterHub. 
 - For a quick tutorial on basic usage, please see [Getting Started](tutorial.md). 
 - To get an in-depth overview of the LEAP Pangeo Architecture and how the JupyterHub fits into it, please see the [Architecture](architecture.md) page.
+
+(jupyterhub.software_env)=
 ## The Software Environment
 The software environment you encounter on the Hub is based upon [docker images](https://www.digitalocean.com/community/tutorials/the-docker-ecosystem-an-introduction-to-common-components) which you can run on other machines (like your laptop or an HPC cluster) for better reproducibility.
 

--- a/book/leap-pangeo/jupyterhub.md
+++ b/book/leap-pangeo/jupyterhub.md
@@ -17,6 +17,7 @@ This document goes over the primary technical details of the JupyterHub.
 - To get an in-depth overview of the LEAP Pangeo Architecture and how the JupyterHub fits into it, please see the [Architecture](architecture.md) page.
 
 (jupyterhub.software_env)=
+
 ## The Software Environment
 
 The software environment you encounter on the Hub is based upon [docker images](https://www.digitalocean.com/community/tutorials/the-docker-ecosystem-an-introduction-to-common-components) which you can run on other machines (like your laptop or an HPC cluster) for better reproducibility.


### PR DESCRIPTION
EDIT: ~Expands Team guide with description of regular tasks (for now only the update of software env versions).~

Adds instructions how to update the software env versions.

