### PR TITLE
Add team instructions about service accounts

### DIFF
--- a/book/guides/team_docs.md
+++ b/book/guides/team_docs.md
@@ -12,6 +12,7 @@ This is a short write up facilitate the spin up of new team members for the Data
 - \[ \] Consider enabling notifications for [](onboarding.github)
 - \[ \] Make a PR to the `_config.yaml` file [here](https://github.com/leap-stc/leap-stc.github.io/blob/fd69890ffc2f1871968e39b1c460370a0b3f98b3/book/_config.yml#L40-L51) in a PR. to add a picture and your personal data to the webpage.
 - \[ \] Get access to the [Grafana Dashboard](https://grafana.leap.2i2c.cloud)
+- \[ \] Request access to a service account to monitor Google Dataflow and Storage from the [Google Cloud Console](https://console.cloud.google.com/welcome?project=leap-pangeo) by raising an issue [here](https://github.com/leap-stc/data-and-compute-team/issues)
 
 (onboarding.slack)=
 
@@ -45,3 +46,7 @@ We aim to provide users with [up-to-date default software environments](jupyterh
 
 - Make sure you are subscribed to release notifications on [pangeo-docker-images](https://github.com/pangeo-data/pangeo-docker-images) to recieve Github notification about new releases
 - To bump the version, submit a PR to [this config file](https://github.com/2i2c-org/infrastructure/blob/master/config/clusters/leap/common.values.yaml) in the [2i2c infrastructure repo](https://github.com/2i2c-org/infrastructure). In that PR you need to change the image tag for *all image choices*, see an example [here](https://github.com/2i2c-org/infrastructure/pull/3688).
+
+## Offboarding members
+
+- [] Delete personal `dct-team-<first_name>` service account in IAM (needs admin priviliges). 

--- a/book/guides/team_docs.md
+++ b/book/guides/team_docs.md
@@ -13,6 +13,12 @@ This is a short write up facilitate the spin up of new team members for the Data
 - \[ \] Make a PR to the `_config.yaml` file [here](https://github.com/leap-stc/leap-stc.github.io/blob/fd69890ffc2f1871968e39b1c460370a0b3f98b3/book/_config.yml#L40-L51) in a PR. to add a picture and your personal data to the webpage.
 - \[ \] Get access to the [Grafana Dashboard](https://grafana.leap.2i2c.cloud)
 - \[ \] Request access to a service account to monitor Google Dataflow and Storage from the [Google Cloud Console](https://console.cloud.google.com/welcome?project=leap-pangeo) by raising an issue [here](https://github.com/leap-stc/data-and-compute-team/issues)
+  - Instructions for admin:
+    - Go to the Google Cloud Console > IAM > Grant Access
+    - Add the following permissions:
+      - `Dataflow Admin`
+      - `Storage Admin`
+      - `Logs Viewer`
 
 (onboarding.slack)=
 

--- a/book/guides/team_docs.md
+++ b/book/guides/team_docs.md
@@ -49,4 +49,4 @@ We aim to provide users with [up-to-date default software environments](jupyterh
 
 ## Offboarding members
 
-- [] Delete personal `dct-team-<first_name>` service account in IAM (needs admin priviliges). 
+- \[\] Delete personal `dct-team-<first_name>` service account in IAM (needs admin priviliges).

--- a/book/guides/team_docs.md
+++ b/book/guides/team_docs.md
@@ -19,6 +19,9 @@ This is a short write up facilitate the spin up of new team members for the Data
       - `Dataflow Admin`
       - `Storage Admin`
       - `Logs Viewer`
+      - `Monitoring Viewer`
+      - `Logs Viewer`
+      - `Compute Viewer`
 
 (onboarding.slack)=
 


### PR DESCRIPTION
Addresses #https://github.com/leap-stc/data-and-compute-team/issues/10 together with some internal documentation that will only be shared with team members for security reasons.