### PR TITLE
Test fixes from pythia upstream

### DIFF
--- a/.github/workflows/publish-book.yaml
+++ b/.github/workflows/publish-book.yaml
@@ -17,6 +17,6 @@ jobs:
 
   deploy:
     needs: build
-    uses: jbusecke/cookbook-actions/.github/workflows/deploy-book.yaml@patch-6
+    uses: ProjectPythia/cookbook-actions/.github/workflows/deploy-book.yaml@main
     with:
       publish_dir: "book/_build/html"

--- a/.github/workflows/trigger-preview.yaml
+++ b/.github/workflows/trigger-preview.yaml
@@ -13,8 +13,7 @@ jobs:
   deploy-preview:
     needs: find-pull-request
     if: github.event.workflow_run.conclusion == 'success'
-    # uses: ProjectPythia/cookbook-actions/.github/workflows/deploy-book.yaml@main
-    uses: jbusecke/cookbook-actions/.github/workflows/deploy-book.yaml@patch-6
+    uses: ProjectPythia/cookbook-actions/.github/workflows/deploy-book.yaml@main
     with:
       artifact_name: book-zip-${{ needs.find-pull-request.outputs.number }}
       destination_dir: _preview/${{ needs.find-pull-request.outputs.number }} # deploy to subdirectory labeled with PR number

--- a/book/intro.md
+++ b/book/intro.md
@@ -1,4 +1,4 @@
-# LEAP Technical Documentation
+# TESTING LEAP Technical Documentation
 
 This website is the home for all technical documentation related to LEAP and LEAP-Pangeo.
 

--- a/book/intro.md
+++ b/book/intro.md
@@ -1,4 +1,4 @@
-# TESTING LEAP Technical Documentation
+# LEAP Technical Documentation
 
 This website is the home for all technical documentation related to LEAP and LEAP-Pangeo.
 


### PR DESCRIPTION
I just noticed that in #192 and https://github.com/leap-stc/leap-stc.github.io/actions/runs/11556651635 I was still running from my PR branch. 

Rebasing onto main (this should really be a release! https://github.com/ProjectPythia/cookbook-actions/issues/112)

- [x] Regular preview works
- [x] Changes here are only displayed in preview (not main site)