### PR TITLE
Fix mkdocs relative links

### DIFF
--- a/docs/compute/hub_access.md
+++ b/docs/compute/hub_access.md
@@ -29,7 +29,7 @@ Another option for accessing *The hub* is connecting with the IDE VSCode.
 
 ![VSCode Jupyter Extension](https://github.com/user-attachments/assets/67f748fc-7ae0-4cc0-a1b5-a6a4ce8b67e1){ align=left }
 
-### Authentication
+### Authentication Options
 
 !!! note
 

--- a/docs/data/data_catalog.md
+++ b/docs/data/data_catalog.md
@@ -1,6 +1,6 @@
-# The LEAP data catalog
+# LEAP data catalog
 
-LEAP maintains a catalog of publically-available datasets available via streaming at
+LEAP maintains a catalog of publicly-available datasets available via streaming at
 [https://catalog.leap.columbia.edu](https://catalog.leap.columbia.edu).
 The catalog includes data that's been ingested (link) from public sources as well as pointers to
 data sets maintained by others. The catalog can be viewed by anyone inside or outside of LEAP.

--- a/docs/data/data_lifecycle.md
+++ b/docs/data/data_lifecycle.md
@@ -1,30 +1,30 @@
-# Data Lifecycles
+# Data Lifecycle
 
-If unfamiliar, you should first check out the overview of our primary [storage locations](data_locations.md) and their use cases. This page is meant to serve as a high level reference. Troubleshooting will inevitably involve the specifics of your data. If anything feels confusing or daunting your first instinct should always be reaching out to the [Data and Compute Team](../support/contact.md)!
+If unfamiliar, you should first check out the overview of our primary [storage locations][where-data-lives] and their use cases. This page is meant to serve as a high level reference. Troubleshooting will inevitably involve the specifics of your data. If anything feels confusing or daunting your first instinct should always be reaching out to the [Data and Compute Team][contact]
 
 ## Getting data into the Cloud
 
-Working on the JupyterHub generally requires transferring whatever data you want to work with into the cloud. The term "data ingestion" refers to a programmatic way to download and transform data into Analysis-Ready Cloud-Optimized (ARCO) formats. One major benefit of doing so is that the data immediately becomes available for the entire LEAP community (it is extremely easy to link ARCO data to the [LEAP Data Catalog](./data_catalog.md))!
+Working on the JupyterHub generally requires transferring whatever data you want to work with into the cloud. The term "data ingestion" refers to a programmatic way to download and transform data into Analysis-Ready Cloud-Optimized (ARCO) formats. One major benefit of doing so is that the data immediately becomes available for the entire LEAP community (it is extremely easy to link ARCO data to the [LEAP Data Catalog][leap-data-catalog])
 The data ingestion process is organized around Github repositories called "feedstocks" that centralize communication with the DCT team for each request.
 
 1. Check if the data has already been made accessible via the catalog. If not, let the LEAP community and the Data and Computation Team know about this new dataset. We gather all ingestion requests in our ['leap-stc/data_management' issue tracker](https://github.com/leap-stc/data-management/issues). You should check existing issues with the tag ['dataset'](https://github.com/leap-stc/data-management/issues?q=is%3Aissue+is%3Aopen+label%3Adataset) to see if somebody else might have already requested this particular dataset. If that is not the case you can add a new [dataset_request](https://github.com/leap-stc/data-management/issues/new?assignees=&labels=dataset&projects=&template=new_dataset.yaml&title=New+Dataset+%5BDataset+Name%5D). Making these requests in a central location enables others to see which datasets are currently being ingested and what the status is.
-1. Use our [feedstock template](https://github.com/leap-stc/LEAP_template_feedstock) to create a feedstock repostory by following instructions in the README to get you started with either one of the above.
-1. If issues arise please reach out to the [Data and Compute Team](../support/contact.md).
+1. Use our [feedstock template](https://github.com/leap-stc/LEAP_template_feedstock) to create a feedstock repository by following instructions in the README to get you started with either one of the above.
+1. If issues arise please reach out to the [Data and Compute Team][contact].
 
 Below we list the most common transfer scenarios and recommend migration workflows for each. Thinking about some of these design choices ahead of time greatly simplifies the back and forth needed by the DCT team when the request eventually comes in. But of course, we can collaborate on the best path forward given the nuances of any particular ingestion request!
 
 ### Migrating Public Data
 
-Very commonly, LEAP members will want to work some publicly accessible data that might live in a data store like Zenodo, NASA, or NOAA. This is the classic ingestion use case for which much of our tooling is designed. If the data is available via HTTP, one powerful method to avoid duplication is to create a *Virtual Zarr Store* (see [file formats](../technical-reference/file_formats.md)).
+Very commonly, LEAP members will want to work some publicly accessible data that might live in a data store like Zenodo, NASA, or NOAA. This is the classic ingestion use case for which much of our tooling is designed. If the data is available via HTTP, one powerful method to avoid duplication is to create a *Virtual Zarr Store* (see [file formats][file-formats]).
 
-Sometimes, climate data is published online but not publically accessible, i.e. it requires some sort of credentials / authorization to access. Even if this is the case, programmatic access is often supported by tooling from the data providers. For example, the Copernicus Data ecosystem has their own API and dataset licenses. Any user-specific access credentials or tokens stored on User Directories are not accessible to other members of the hub; they remain private. However, they can be viewed by LEAP Data and Compute admins; if this is an issue, please consult us for alternative ingestion options.
+Sometimes, climate data is published online but not publicly accessible, i.e. it requires some sort of credentials / authorization to access. Even if this is the case, programmatic access is often supported by tooling from the data providers. For example, the Copernicus Data ecosystem has their own API and dataset licenses. Any user-specific access credentials or tokens stored on User Directories are not accessible to other members of the hub; they remain private. However, they can be viewed by LEAP Data and Compute admins; if this is an issue, please consult us for alternative ingestion options.
 
 ### Migrating HPC Data
 
 Many LEAP Scientists also have access to an HPC or external filesystem on which their data is being generated. The biggest reason to ingest such data is for collaboration.
 If the data is located behind a firewall on an HPC center, the normal 'pull' based paradigm of our feedstocks will not work. In this case we have an option to 'push' the data to a special "inbox" bucket (`'leap-pangeo-inbox'`) on the OSN Pod. Once the data is in this accessible intermediate staging area, the process and tools documented on the [feedstock template](https://github.com/leap-stc/LEAP_template_feedstock) ought to work.
 
-The biggest barrier here is external authentication; see the [Authentication section](../technical-reference/authentication.md) for how to do this. Once authenticated, users can initiate a data transfer from their 'local' machine (laptop, server, or HPC Cluster) with the tools documented below.
+The biggest barrier here is external authentication; see the [Authentication section][authentication] for how to do this. Once authenticated, users can initiate a data transfer from their 'local' machine (laptop, server, or HPC Cluster) with the tools documented below.
 
 ## Data Tooling
 

--- a/docs/data/data_locations.md
+++ b/docs/data/data_locations.md
@@ -53,7 +53,7 @@ A common workflow is for data to be private --> get ingested to LEAP GCS --> OSN
 
 ## LEAP-Pangeo Cloud Buckets
 
-LEAP-Pangeo provides users two cloud buckets to store data. The JupyterHub is automatically authenticated to read from any of these buckets but write access might differ (see below). See [Authentication](../technical-reference/authentication.md) for details on how to access buckets from 'outside' the JupyterHub.
+LEAP-Pangeo provides users two cloud buckets to store data. The JupyterHub is automatically authenticated to read from any of these buckets but write access might differ (see below). See [Authentication][authentication] for details on how to access buckets from 'outside' the JupyterHub.
 Google cloud is structured such that it is very easy and cheap to move data *into* the buckets, but there are high egress fees for taking data out of GCP Infrastructure. Taking data out means both writing from GCP to outside and reading from an external source like an HPC.
 !!! tip
 TLDR: Use the LEAP GCS buckets when you are actively doing science using the JupyterHub. If you wish to share some kind of finished product with the world, it is best to "publish" the data by moving outside GCS into OSN.
@@ -95,7 +95,7 @@ OSN is great if:
 \- You need to move data from your Jupyter-Hub home directory to more persistent storage.
 \- You data does not fit into the Zarr model.
 
-To migrate data to OSN, please contact the data-and-compute team on slack. They will contact the OSN pod admin and share bucket credentials for the `'leap-pangeo-inbox'` bucket. More details are provided under [authentication](../technical-reference/authentication.md).
+To migrate data to OSN, please contact the data-and-compute team on slack. They will contact the OSN pod admin and share bucket credentials for the `'leap-pangeo-inbox'` bucket. More details are provided under [authentication][authentication].
 
 # Private Storage - HPC or External Filesystems
 

--- a/docs/edu/bootcamps.md
+++ b/docs/edu/bootcamps.md
@@ -1,0 +1,55 @@
+# Running Bootcamps
+
+Bootcamp materials in the [LEAP-Pangeo bootcamp repository](https://github.com/leap-stc/LEAP-bootcamps). Please add the materials you develop for your bootcamp to this repo as described below.
+
+## Preparing for the bootcamp
+
+**Past attendees have suggested that it is very helpful to have the instructor write code from scratch.**
+This ensures the following:
+
+- The lecturer takes substantially more time to write live, ensuring that others can follow along.
+- The lecturer is not a superhuman, but also makes mistakes and has to debug code. This is a very important lesson for students to learn, as it is a very common part of the coding process and often not shown in lectures.
+- It also allows the lecturer to explain the code as they write it, which is a very important part of the learning process.
+
+If it is necessary to use a notebook pre-populated with code, please clear all outputs prior to starting the lecture by following this procedure:
+
+- In the Jupyter notebook, click on `Edit` in the top taskbar.
+- Find and click `Clear Outputs of All Cells` from the dropdown menu.
+- Save Jupyter notebook with cleared outputs by clicking `Save` from the top taskbar and then clicking `Save Notebook`.
+- After the lecture is over, save the Jupyter notebook again to save the complete version with all outputs.
+
+## Materials for the bootcamp
+
+We encourage you to reuse materials from past bootcamps and adapt them to your needs. If you re-use material from previous bootcamps, please don't modify the original notebooks, instead create new copies for your use.
+
+- Create a new folder in the "Codes" and "Lectures" folders and add your materials there. *If you are giving the same material as a previous bootcamp, please copy them.*
+  !!! warning
+  If you are using materials from other sources, like the [An Introduction to Earth and Environmental Data Science](https://earth-env-data-science.github.io/intro.html) book. Please just follow the past events structure and link to the original materials.
+
+- [README.md](https://github.com/leap-stc/LEAP-bootcamps/README.md) Enter a new entry under the "Events" section. This should include an [nbgitpuller](https://nbgitpuller.readthedocs.io/en/latest/) link for each notebook you work with, so participants can easily pull the materials to their hub (there is a neat tool to [generate these links](https://nbgitpuller.readthedocs.io/en/latest/link.html)). Please also use the LEAP-Pangeo Hub badge by adding code like this:
+
+  ```
+  [![Open in LEAP-Pangeo Hub](https://custom-icon-badges.demolab.com/badge/Jupyter%20Hub-Launch%20%F0%9F%9A%80-blue?style=for-the-badge&logo=leap-globe)](<generated_link>) 
+  ```
+
+## Running the bootcamp
+
+### Prepare ahead of the event
+
+Bootcamp instructors should make sure that they are added to the [Bootcamp Instructors Github Team](https://github.com/orgs/leap-stc/teams/bootcamp-instructors) by contacting the data and compute team. This ensures that the people running the bootcamp can perform tasks that might be needed the day of (mostly likely signing up folks who either entered wrong data or did not register ahead of time).
+
+Before the event check the following:
+
+- Is somebody available to add new data to the Member Data Google Sheet? LEAPs Managing Director has the ability to add data or give others edit access.
+- Can the instructors manually trigger the ["Parse Member Sheet and Add New Members" action](https://github.com/leap-stc/member_management/actions/workflows/read_sheet.yaml) (by clicking on "Run Workflow>Run Workflow" in the top right).
+- Double Check that all participants github names are present in the [leap-pangeo-base-access](https://github.com/orgs/leap-stc/teams/leap-pangeo-base-access) team! If folks are in this team they will have access to the hub! If they are not there they either have not accepted the invite to the team (they will be shown as pending invites; tell them to accept the invite as described [here](https://leap-stc.github.io/guides/faq.html#where-is-my-invite)) or there is an issue with their github username (check their github handles in the Member Data Google Sheet for typos and completeness). We recommend that you familiarize yourself and test these steps ahead of time.
+
+If you are anticipating many attendees to access the hub at the same time to follow along, it is useful to consult with the [Data & Compute Team][contact] or 2i2c beforehand to ensure a smooth presentation.
+
+### Troubleshooting during the event
+
+If students have trouble signing in to the hub, please refer to the **FAQ** for troubleshooting steps.
+
+## After the event
+
+Please add your versions of the filled notebooks to a subfolder named `filled_notebooks` in the event folder you created above, so participants and future instructors can access them later.

--- a/docs/introduction/what_is_the_hub.md
+++ b/docs/introduction/what_is_the_hub.md
@@ -4,13 +4,13 @@ LEAP's primary data and computational resources are available through the LEAP J
 
 The hub is designed around **interactive** use though long computations are possible.
 
-To gain access to the Hub please see the [Registration page][Registration]. LEAP's Jupyterhub is managed by our partner [2i2c](https://2i2c.org).
+To gain access to the Hub please see the [Registration page][registration]. LEAP's Jupyterhub is managed by our partner [2i2c](https://2i2c.org).
 
 The Hub includes
 
-- **computing resources** accessible nearly world-wide via a web brower or via VSCode as described on [this page][Accessing the hub]. The resources include a variety of hardware configurations and a range of pre-defined but evolving sets of software.
+- **computing resources** accessible nearly world-wide via a web brower or via VSCode as described on [this page][accessing-the-hub]. The resources include a variety of hardware configurations and a range of pre-defined but evolving sets of software.
 
-- **data resources** divided among generous shared "cloud buckets" for data and limited home directories for scripts etc. as described at [Where Data Lives][Where Data Lives]
+- **data resources** divided among generous shared "cloud buckets" for data and limited home directories for scripts etc. as described at [Where Data Lives][where-data-lives]
 
 The computing resources have fast access to LEAP's data resources; they also have fast connections to the boader internet which lowers the barrier to working with data held elsewhere.
 
@@ -19,4 +19,4 @@ Compared to using
 - a *laptop*, the Hub offers fast access to data and the ability to access much more powerful computational resources including GPUs for ML training tasks.
 - *HPCs, clusters, etc.* the hub offers simpler access and less competition for resources (since the pool from which the resources are drawn is enormous). It does not, however, easily support non-interactive use.
 
-Moving data in to data resources is free; moving data out is expensive (see [Data Lifecycles][Data Lifecycles]). Please plan your workflow accordingly.
+Moving data in to data resources is free; moving data out is expensive (see [Data Lifecycles][data-lifecycle]). Please plan your workflow accordingly.

--- a/docs/support/contact.md
+++ b/docs/support/contact.md
@@ -1,0 +1,14 @@
+# Contact
+
+The preferred way to contact the Data & Compute Team is via the Slack Workspace **LEAP-NSF-STC**
+
+## Ask a Question on the LEAP Slack Workspace
+
+- Request access to the LEAP Slack by contacting ...
+- Once you are given access, add yourself to relevant channels listed below within the workspace
+- Search these two channels to see if anyone else had similar questions - chances are, the solution to your questions are already here!
+- If issue persists after trying previous solutions, then let us know by posting a new thread and tagging us at `@data-and-compute`!
+
+!!! note
+`leap-pangeo`: channel for non-technical support for LEAP-Pangeo (Questions pertaining to Hub access, Education, etc.)
+`technical_questions`: channel for community-wide support on technical issues

--- a/docs/technical-reference/authentication.md
+++ b/docs/technical-reference/authentication.md
@@ -6,7 +6,7 @@ Authenticating to LEAP Resources is a frequent pain point reported by our users.
 
 **Step by Step instructions**
 
-1. Reach out to the [](support.data_compute_team). They will contact the OSN pod admin and share bucket credentials for the `'leap-pangeo-inbox'` bucket.
+1. Reach out to the [the data-and-compute team][contact]. They can share bucket credentials for the `'leap-pangeo-inbox'` bucket.
 1. How you exactly achieve the upload will depend on your preference. Some common options include:
    - Load / Aggregate your NetCDF files using xarray and save the output to Zarr using `.to_zarr(...)`
    - Use fsspec or rclone to move an existing zarr store to the target bucket

--- a/docs/technical-reference/faqs.md
+++ b/docs/technical-reference/faqs.md
@@ -20,33 +20,33 @@ You can follow that and accept the invitation there aswell.
 
 If you are unable to log into the hub, please check the following steps:
 
-- [ ] Check if you are member of the [appropriate github teams](reference.membership.tiers).
+- [ ] Check if you are member of the [appropriate github teams]\<MISSING SECTION?>.
 
 If you **are not** follow these steps:
 
-- [ ] Did you [sign up for LEAP membership](users.membership.apply)? This will be done for you if you sign up for an event like the Momentum bootcamp!
+- [ ] Did you [sign up for LEAP membership]\<MISSING SECTION?> This will be done for you if you sign up for an event like the Momentum bootcamp!
 - [ ] Did you receive a github invite? See above for how to check for that.
 - [ ] Check again if they are part of the appropriate github teams.
-- If these steps do not work, please reach out to the [Data and Compute Team](../support/contact.md).
+- If these steps do not work, please reach out to the [Data and Compute Team][contact].
 
 If you **are** member of one of the github teams, ask them to try the following steps:
 
 - [ ] Refresh the browser cache
 - [ ] Try a different browser
 - [ ] Restart the computer
-- If these steps do not work, please reach out to the [Data and Compute Team](../support/contact.md).
+- If these steps do not work, please reach out to the [Data and Compute Team][contact].
 
 ## I received a warning about space on my User Directory
 
-If you get a Hub Usage Alert email, this means you are violating the User Directory storage limit (to learn why this limit exists, see read about [User Directories](reference.infrastructure.hub.user_dir)). Remember that user directories are for scripts and notebooks not datasets! Users who persistently violate hub usage policies may temporarily get reduced cloud access.
+If you get a Hub Usage Alert email, this means you are violating the User Directory storage limit (to learn why this limit exists, see read about [User Directories][user-directory]). Remember that user directories are for scripts and notebooks not datasets! Users who persistently violate hub usage policies may temporarily get reduced cloud access.
 
 **Troubleshooting**
 
 - To see which files and directories are taking up the bulk of your storage, run `du -h --max-depth=1 ~/ | sort -h` in Terminal. It will likely reveal cached files and small/medium size data files that can be removed without disrupting typical usage.
 - Delete cached files, ipython checkpoints, and any other unwanted files.
-- If you still require more storage, it is likely that you are storing downloaded data in your user directory. We recommend storing data in a LEAP cloud bucket or data catalog. For more information, please consult our [data locations](../data/data_locations.md).
+- If you still require more storage, it is likely that you are storing downloaded data in your user directory. We recommend storing data in a LEAP cloud bucket or data catalog. For more information, please consult our [data locations][where-data-lives].
 
-Our goal is to accomodate all community members and thus we are happy to assist users in relocating data. If you have any concerns, please reach out to the [Data and Compute Team](../support/contact.md).
+Our goal is to accomodate all community members and thus we are happy to assist users in relocating data. If you have any concerns, please reach out to the [Data and Compute Team][contact].
 
 ## Dask "Killed Workers"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,6 @@ nav:
       - introduction/getting_started.md
   - Data:
       - data/data_catalog.md
-      - data/data_policy.md
       - data/data_locations.md
       - data/data_lifecycle.md
   - Compute:


### PR DESCRIPTION
You can link to headings in separate pages without a relative `../` syntax by providing the markdown header in with lowercase and `-` separated words.

Ex: [Check out our data access policy][data-access-policy]

Which might look like
`data-access.md`
```md

# Data access policy
```

Docs: https://mkdocstrings.github.io/autorefs/